### PR TITLE
Remove stray backticks from doc comments

### DIFF
--- a/src/Data/Newtype.purs
+++ b/src/Data/Newtype.purs
@@ -25,7 +25,6 @@ import Safe.Coerce (class Coercible, coerce)
 -- | defined as `newtype` rather than `data` declaration (even if the `data`
 -- | structurally fits the rules of a `newtype`), and the use of a wildcard for
 -- | the wrapped type.
--- | ```
 class Newtype :: Type -> Type -> Constraint
 class Coercible t a <= Newtype t a | t -> a
 


### PR DESCRIPTION
**Description of the change**

Just removed stray backticks that caused an empty code block to show up in the generated documentation.

Do I need to add an entry in the changelog for this? It seems unnecessary.

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)