### PR TITLE
Remove incorrect newtype deriving in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Remove incorrect newtype deriving from `over2` docs (#33 by @ptrfrncsmrph)
 
 ## [v5.0.0](https://github.com/purescript/purescript-newtype/releases/tag/v5.0.0) - 2022-04-27
 

--- a/src/Data/Newtype.purs
+++ b/src/Data/Newtype.purs
@@ -219,9 +219,9 @@ underF _ = coerce
 -- |
 -- | ``` purescript
 -- | newtype Meter = Meter Int
--- | derive newtype instance newtypeMeter :: Newtype Meter _
+-- | derive instance newtypeMeter :: Newtype Meter _
 -- | newtype SquareMeter = SquareMeter Int
--- | derive newtype instance newtypeSquareMeter :: Newtype SquareMeter _
+-- | derive instance newtypeSquareMeter :: Newtype SquareMeter _
 -- |
 -- | area :: Meter -> Meter -> SquareMeter
 -- | area = over2 Meter (*)


### PR DESCRIPTION
**Description of the change**

The code snippet in the `over2` documentation doesn't compile
```haskell
newtype Meter = Meter Int
derive newtype instance newtypeMeter :: Newtype Meter _
newtype SquareMeter = SquareMeter Int
derive newtype instance newtypeSquareMeter :: Newtype SquareMeter _
```

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
